### PR TITLE
Don't wait until a bundle has been published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <checksums>all</checksums>
-                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
By default, the plugin waits until the server has validated the bundle. In case a file is missing or the bundle is broken, the build fails.

By waiting until `published` the shell session is unnecessarily blocked, until the artifacts are published to download (!!) on the central repository.
In my case, this took me quite a few hours to cut a new release of archetypes.