### PR TITLE
Side-port SpotBugs support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,38 @@
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
+    <!--
+      The following bug patterns are noisy and create little value; therefore, we suppress them
+      globally.
+
+      ConstructorThrow
+        CT_CONSTRUCTOR_THROW
+      FindReturnRef
+        EI_EXPOSE_BUF2
+        EI_EXPOSE_REP
+        EI_EXPOSE_REP2
+        EI_EXPOSE_STATIC_BUF2
+        EI_EXPOSE_STATIC_REP2
+        MS_EXPOSE_BUF
+        MS_EXPOSE_REP
+      MultipleInstantiationsOfSingletons
+        SING_SINGLETON_GETTER_NOT_SYNCHRONIZED
+        SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR
+        SING_SINGLETON_IMPLEMENTS_CLONEABLE
+        SING_SINGLETON_IMPLEMENTS_CLONE_METHOD
+        SING_SINGLETON_IMPLEMENTS_SERIALIZABLE
+        SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE
+      SharedVariableAtomicityDetector
+        AT_NONATOMIC_64BIT_PRIMITIVE
+        AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE
+        AT_STALE_THREAD_WRITE_OF_PRIMITIVE
+      ThrowingExceptions
+        THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION
+        THROWS_METHOD_THROWS_CLAUSE_THROWABLE
+        THROWS_METHOD_THROWS_RUNTIMEEXCEPTION
+    -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef,MultipleInstantiationsOfSingletons,SharedVariableAtomicityDetector,ThrowingExceptions</spotbugs.omitVisitors>
+
     <!-- Set to false to enable Spotless -->
     <spotless.check.skip>true</spotless.check.skip>
 
@@ -87,8 +119,20 @@
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+    <spotbugs-annotations.version>4.9.4</spotbugs-annotations.version>
+    <spotbugs-maven-plugin.version>4.9.4.1</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugs-annotations.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>
@@ -97,6 +141,11 @@
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${spotbugs-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -171,6 +220,24 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>spotbugs</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+            <!--
+              Do not define "excludeFilterFile" here, as it will force consumers to provide a file.
+              Instead, we configure this below in a profile conditionally activated based on the
+              presence of this file.
+            -->
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
@@ -305,6 +372,30 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>spotbugs-exclusion-file</id>
+      <activation>
+        <file>
+          <exists>${basedir}/src/spotbugs/excludesFilter.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotbugs</id>
+                <configuration>
+                  <excludeFilterFile>${project.basedir}/src/spotbugs/excludesFilter.xml</excludeFilterFile>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Side-porting this from the regular parent POM, since we tend to use it in downstream consumers and duplicate code is undesirable. Tested in context in `syslog-java-client` by introducing a SpotBugs violation and ensuring it was flagged.